### PR TITLE
Added OCR/DCR calculations and fixed HP and AC calculation errors

### DIFF
--- a/src/components/ArmorClassSection.js
+++ b/src/components/ArmorClassSection.js
@@ -26,6 +26,14 @@ const ArmorClassSection = ({ armorClass, updateArmorClass, dexterity }) => {
     updateArmorClass(type, ac);
   };
 
+  const handleCustomACChange = (value) => {
+    const newAC = parseInt(value);
+    setCustomAC(newAC);
+    if (armorCategory === 'natural') {
+      updateArmorClass('Natural Armor', newAC);
+    }
+  };
+
   const getArmorFormula = (type) => {
     const info = armorTypes[type];
     let formula = `${info.base}`;
@@ -94,7 +102,7 @@ const ArmorClassSection = ({ armorClass, updateArmorClass, dexterity }) => {
           <input
             type="number"
             value={customAC}
-            onChange={(e) => setCustomAC(parseInt(e.target.value))}
+            onChange={(e) => handleCustomACChange(e.target.value)}
             className="w-full p-2 border rounded"
             min="1"
           />

--- a/src/components/StatblockPreview.js
+++ b/src/components/StatblockPreview.js
@@ -1,19 +1,14 @@
 import React from 'react';
-import { calculateModifier, calculateHP, calculateCR, getHitDieSize, calculateDCR, calculateOCR, getXPFromCR, getProficiencyBonus } from '../utils/calculations';
+import { calculateModifier, calculateHP, calculateCR, getHitDieSize, formatCR, getProficiencyBonus, getXPFromCR } from '../utils/calculations';
 
 export const StatblockPreview = ({ statblock }) => {
   const { name, size, abilityScores, armorClass, hitDice, actions } = statblock;
-  const hp = calculateHP(size, hitDice, calculateModifier(abilityScores.CON));
-  const dcr = calculateDCR(hp, armorClass.value);
-  
-  // TODO: Implement proper DPR and attack bonus calculations
-  const dpr = 10; // Placeholder
-  const attackBonus = 3 + calculateModifier(abilityScores.STR); // Placeholder
-  
-  const ocr = calculateOCR(dpr, attackBonus);
-  const cr = calculateCR(hp, armorClass.value, dpr, attackBonus);
-  const xp = getXPFromCR(cr);
+  const hitDieSize = getHitDieSize(size);
+  const conModifier = calculateModifier(abilityScores.CON);
+  const hp = calculateHP(size, hitDice, conModifier);
+  const { cr, ocr, dcr } = calculateCR(hp, armorClass.value, actions, abilityScores);
   const proficiencyBonus = getProficiencyBonus(cr);
+  const xp = getXPFromCR(cr);
 
   const calculateAverageDamage = (damageDice, bonus) => {
     const [diceCount, dieType] = damageDice.split('d');
@@ -49,7 +44,7 @@ export const StatblockPreview = ({ statblock }) => {
       
       <div className="mb-4">
         <p><strong>Armor Class</strong> {armorClass.value} ({armorClass.type})</p>
-        <p><strong>Hit Points</strong> {hp} ({hitDice}d{getHitDieSize(size)} + {calculateModifier(abilityScores.CON) * hitDice})</p>
+        <p><strong>Hit Points</strong> {hp} ({hitDice}d{hitDieSize} + {conModifier * hitDice})</p>
         <p><strong>Speed</strong> 30 ft.</p>
       </div>
 
@@ -72,7 +67,7 @@ export const StatblockPreview = ({ statblock }) => {
       </div>
 
       <div className="border-t-2 border-accent pt-2">
-        <p><strong>Challenge</strong> {cr} ({xp} XP)</p>
+        <p><strong>Challenge</strong> {formatCR(cr, ocr, dcr)} ({xp} XP)</p>
         <p><strong>Proficiency Bonus</strong> +{proficiencyBonus}</p>
       </div>
     </div>

--- a/src/hooks/useStatblock.js
+++ b/src/hooks/useStatblock.js
@@ -13,17 +13,28 @@ export const useStatblock = () => {
   const [actions, setActions] = useState([{ name: '', description: '', attack: null }]);
 
   useEffect(() => {
-    updateArmorClass(armorClass.type);
-  }, [abilityScores.DEX, armorClass.type]);
+    updateArmorClass(armorClass.type, armorClass.value);
+  }, [abilityScores.DEX]);
 
-  const updateArmorClass = (type, customValue) => {
+  const updateArmorClass = (type, customValue = null) => {
     const armorInfo = armorTypes[type];
-    let newAC = armorInfo.base;
-    if (armorInfo.useDex) {
-      const dexMod = calculateModifier(abilityScores.DEX);
-      newAC += armorInfo.maxDex ? Math.min(dexMod, armorInfo.maxDex) : dexMod;
+    let newAC;
+
+    if (type === 'Natural Armor' && customValue !== null) {
+      newAC = customValue;
+    } else if (armorInfo) {
+      newAC = armorInfo.base;
+      if (armorInfo.useDex) {
+        const dexMod = calculateModifier(abilityScores.DEX);
+        newAC += armorInfo.maxDex ? Math.min(dexMod, armorInfo.maxDex) : dexMod;
+      }
+    } else {
+      // Default to unarmored if type is not recognized
+      newAC = 10 + calculateModifier(abilityScores.DEX);
+      type = 'Unarmored';
     }
-    setArmorClass({ type, value: type === 'Custom' ? customValue : newAC });
+
+    setArmorClass({ type, value: newAC });
   };
 
   const addNewAction = () => {

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -5,10 +5,33 @@ export const calculateModifier = (score) => Math.floor((score - 10) / 2);
 
 export const calculateHP = (size, hitDice, conMod) => {
   const hitDieSize = sizeDice[size] || 8;
-  return hitDice * (Math.ceil(hitDieSize / 2) + conMod);
+  const averageRoll = (hitDieSize + 1) / 2; // This gives the correct average (e.g., 4.5 for d8)
+  const totalHP = hitDice * (averageRoll + conMod);
+  return Math.floor(totalHP); // Only round down after calculating the total HP
 };
 
 export const getHitDieSize = (size) => sizeDice[size] || 8;
+
+export const calculateAverageDamage = (damageDice, damageBonus) => {
+  const [diceCount, dieType] = damageDice.split('d');
+  const averageDieRoll = (parseInt(dieType) + 1) / 2;
+  return Math.floor(diceCount * averageDieRoll) + damageBonus;
+};
+
+export const findHighestDamageAttack = (actions, abilityScores, proficiencyBonus) => {
+  return actions.reduce((highestDamage, action) => {
+    if (action.attack) {
+      const abilityMod = calculateModifier(abilityScores[action.attack.abilityScore]);
+      const damageBonus = action.attack.addAbilityToDamage ? abilityMod : 0;
+      const averageDamage = calculateAverageDamage(action.attack.damageDice, damageBonus);
+      const toHit = abilityMod + proficiencyBonus;
+      if (averageDamage > highestDamage.damage) {
+        return { damage: averageDamage, attack: action.attack, toHit };
+      }
+    }
+    return highestDamage;
+  }, { damage: 0, attack: null, toHit: 0 });
+};
 
 export const calculateDCR = (hp, ac) => {
   const baseCR = findCRByHP(hp).cr;
@@ -17,20 +40,55 @@ export const calculateDCR = (hp, ac) => {
   return adjustCR(baseCR, acDifference);
 };
 
-export const calculateOCR = (dpr, attackBonus) => {
-  const baseCR = findCRByDPR(dpr).cr;
+export const calculateOCR = (actions, abilityScores, proficiencyBonus) => {
+  const { damage, toHit } = findHighestDamageAttack(actions, abilityScores, proficiencyBonus);
+  if (damage === 0) return 0;
+
+  const baseCR = findCRByDPR(damage).cr;
   const expectedAttackBonus = crTableData.find(row => row.cr === baseCR).attackBonus;
-  const attackBonusDifference = Math.floor((attackBonus - expectedAttackBonus) / 2);
+  
+  const attackBonusDifference = Math.floor((toHit - expectedAttackBonus) / 2);
+  
   return adjustCR(baseCR, attackBonusDifference);
 };
 
-export const calculateCR = (hp, ac, dpr, attackBonus) => {
+export const calculateCR = (hp, ac, actions, abilityScores) => {
   const dcr = calculateDCR(hp, ac);
-  const ocr = calculateOCR(dpr, attackBonus);
+  const proficiencyBonus = getProficiencyBonus(dcr);
+  const ocr = calculateOCR(actions, abilityScores, proficiencyBonus);
   const averageCR = (dcr + ocr) / 2;
-  return crTableData.reduce((prev, curr) => 
+
+  // If averageCR is less than 1, round up to the nearest valid CR
+  if (averageCR < 1) {
+    const validLowCRs = [0, 0.125, 0.25, 0.5, 1];
+    return {
+      cr: validLowCRs.find(cr => cr >= averageCR) || 1,
+      ocr: ocr,
+      dcr: dcr
+    };
+  }
+
+  // For CR 1 and above, find the nearest CR as before
+  const finalCR = crTableData.reduce((prev, curr) => 
     Math.abs(curr.cr - averageCR) < Math.abs(prev.cr - averageCR) ? curr : prev
   ).cr;
+
+  return {
+    cr: finalCR,
+    ocr: ocr,
+    dcr: dcr
+  };
+};
+
+export const formatCR = (cr, ocr, dcr) => {
+  const formatFraction = (num) => {
+    if (num === 0.125) return "1/8";
+    if (num === 0.25) return "1/4";
+    if (num === 0.5) return "1/2";
+    return num.toString();
+  };
+
+  return `${formatFraction(cr)} (OCR ${formatFraction(ocr)}, DCR ${formatFraction(dcr)})`;
 };
 
 export const getXPFromCR = (cr) => {


### PR DESCRIPTION
This PR implements the following changes:
- Add offensive Challenge Rating (OCR) calculation
- Update overall CR calculation to consider both OCR and DCR
- Fix HP calculation to use correct die averages
- Implement rounding up for low CRs (below 1)